### PR TITLE
Cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Load files into memory to be parsed & traversed using Babylon/Babel",
   "main": "index.js",
-  "repository": "thejameskyle/babel-multi-file",
+  "repository": "babel-utils/babel-file-loader",
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "MIT",
   "files": [],
@@ -13,7 +13,6 @@
   "dependencies": {
     "babel-errors": "^1.0.1",
     "babel-file": "^3.0.0",
-    "babel-plugin-tester": "^3.0.0",
     "babel-types": "^6.24.1",
     "read-file-async": "^1.0.0",
     "resolve": "^1.3.3",


### PR DESCRIPTION
- remove unused dependencies
- fixes repository link

Stumbled upon this while looking at dependents of `babel-plugin-tester` in npm and the repository link for this package gave a 404 and `babel-plugin-tester` wasn't even used unfortunately.